### PR TITLE
Remove unnecessary ternary operation

### DIFF
--- a/library/Models/Companies.php
+++ b/library/Models/Companies.php
@@ -320,7 +320,7 @@ class Companies extends \Gewaer\CustomFields\AbstractCustomFieldsModel
      */
     public function userAssociatedToCompany(Users $user): bool
     {
-        return is_object($this->getUsersAssociatedCompanies('users_id =' . $user->getId())) ? true : false;
+        return is_object($this->getUsersAssociatedCompanies('users_id =' . $user->getId()));
     }
 
     /**


### PR DESCRIPTION
`is_object` returns a bool value, so you just need to return the is_object result.