### PR TITLE
Load App classes and test namespaces using composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,21 @@
     "sort-packages": true,
     "optimize-autoloader": true
   },
+  "autoload": {
+    "classmap": [
+      "api",
+      "library",
+      "cli/tasks"
+    ]
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Niden\\Tests\\": "tests/",
+      "Gewaer\\Tests\\": "tests/"
+    }
+  },
   "scripts": {
+    "test": "./vendor/bin/codecept run",
     "phpcs": "phpcs --standard=PSR2"
   }
 }

--- a/library/Core/autoload.php
+++ b/library/Core/autoload.php
@@ -1,31 +1,12 @@
 <?php
 
 use Dotenv\Dotenv;
-use Phalcon\Loader;
 use function Canvas\Core\appPath;
 
 // Register the auto loader
-//require __DIR__ . '/functions.php';
-//require  '/canvas-core/src/Core/functions.php';
 require dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . '/vendor/canvas/core/src/Core/functions.php';
 
-$loader = new Loader();
-$namespaces = [
-    //    'Canvas' => '/canvas-core/src',
-    'Gewaer' => appPath('/library'),
-    'Gewaer\Api\Controllers' => appPath('/api/controllers'),
-    'Gewaer\Cli\Tasks' => appPath('/cli/tasks'),
-    'Niden\Tests' => appPath('/tests'),
-    'Gewaer\Tests' => appPath('/tests')
-];
-
-$loader->registerNamespaces($namespaces);
-
-$loader->register();
-
-/**
- * Composer Autoloader.
- */
+// Composer Autoloader.
 require appPath('vendor/autoload.php');
 
 // Load environment


### PR DESCRIPTION
Instead of look for all the classes that we have in the app every time the app boots, we should use composer to create a static classmap file with all the classes to be loaded to avoid rediscovering classes each request.

