### PR TITLE
[0.2] Define UserProfile Provider

### DIFF
--- a/api/config/providers.php
+++ b/api/config/providers.php
@@ -26,7 +26,7 @@ use Canvas\Providers\ElasticProvider;
 use Canvas\Providers\SocialLoginProvider;
 use Gewaer\Providers\MiddlewareProvider;
 use Canvas\Providers\RegistryProvider;
-use Canvas\Providers\UserProvider;
+use Gewaer\Providers\UserProvider;
 use Canvas\Providers\ViewProvider;
 
 return [

--- a/cli/config/providers.php
+++ b/cli/config/providers.php
@@ -21,6 +21,7 @@ use Gewaer\Providers\ErrorHandlerProvider;
 use Gewaer\Providers\EventsManagerProvider;
 use Gewaer\Providers\MailProvider;
 use Gewaer\Providers\ModelsMetadataProvider;
+use Gewaer\Providers\UserProvider;
 
 return [
     ConfigProvider::class,
@@ -39,5 +40,6 @@ return [
     PusherProvider::class,
     AclProvider::class,
     FileSystemProvider::class,
-    EventsManagerProvider::class
+    EventsManagerProvider::class,
+    UserProvider::class
 ];

--- a/library/Providers/UserProvider.php
+++ b/library/Providers/UserProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gewaer\Providers;
+
+use Gewaer\Models\Users;
+use Phalcon\Di\DiInterface;
+use Phalcon\Di\ServiceProviderInterface;
+
+class UserProvider implements ServiceProviderInterface
+{
+    /**
+     * UserProvider to specify the default user return type.
+     *
+     * @param DiInterface $container
+     */
+    public function register(DiInterface $container) : void
+    {
+        $container->setShared(
+            'userProvider',
+            function () {
+                return new Users();
+            }
+        );
+    }
+}


### PR DESCRIPTION
- Overwrite the default kanvas userProfile Provider, to use the app user object type